### PR TITLE
Wire PROXY_IMAGE_* template vars through Makefile lint/build-full

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ ZARF_VERSION:="0.59.0"
 GITEA_VERSION:="1.24.4"
 # renovate: depName=distribution/distribution
 REGISTRY_VERSION:="3.0.0"
+# renovate: depName=alpine/socat
+PROXY_VERSION:="1.8.0.3"
 
 ZARF_DIR:="zarf"
 BUILD_DIR:="../../build"
@@ -20,6 +22,9 @@ lint:
 	--set AGENT_IMAGE_DOMAIN="registry1.dso.mil/" \
 	--set AGENT_IMAGE="ironbank/opensource/defenseunicorns/zarf/zarf-agent" \
 	--set AGENT_IMAGE_TAG=v$(ZARF_VERSION) \
+	--set PROXY_IMAGE_DOMAIN="registry1.dso.mil/" \
+	--set PROXY_IMAGE="ironbank/opensource/alpine/socat/socat" \
+	--set PROXY_IMAGE_TAG=$(PROXY_VERSION) \
 	--set INJECTOR_VERSION="2025-03-24" \
 	--set INJECTOR_AMD64_SHASUM="a78d66b9e2b00a22edd9b4e6432a4d934621e3757f09493b12f688c7c9baca93" \
 	--set GITEA_IMAGE=registry1.dso.mil/ironbank/opensource/go-gitea/gitea:v$(GITEA_VERSION)
@@ -34,6 +39,9 @@ build-full:
 	--set AGENT_IMAGE_DOMAIN="registry1.dso.mil/" \
 	--set AGENT_IMAGE="ironbank/opensource/defenseunicorns/zarf/zarf-agent" \
 	--set AGENT_IMAGE_TAG=v$(ZARF_VERSION) \
+	--set PROXY_IMAGE_DOMAIN="registry1.dso.mil/" \
+	--set PROXY_IMAGE="ironbank/opensource/alpine/socat/socat" \
+	--set PROXY_IMAGE_TAG=$(PROXY_VERSION) \
 	--set INJECTOR_VERSION="2025-03-24" \
 	--set INJECTOR_AMD64_SHASUM="a78d66b9e2b00a22edd9b4e6432a4d934621e3757f09493b12f688c7c9baca93" \
 	--set GITEA_IMAGE=registry1.dso.mil/ironbank/opensource/go-gitea/gitea:v$(GITEA_VERSION) && \


### PR DESCRIPTION
## Summary

- Adds a `PROXY_VERSION` Makefile variable pinned to `alpine/socat` 1.8.0.3 (Renovate-tracked).
- Adds the three `--set PROXY_IMAGE_DOMAIN/IMAGE/TAG` flags to both the `lint` and `build-full` Makefile targets, pointing at the IronBank `alpine/socat/socat` image.
- `build-minimal` is intentionally untouched — it doesn't import the upstream zarf packages, so it doesn't need these flags.

This is the k3s-ha equivalent of radiusmethod/zarf-init-bigbang#94 (which closed radiusmethod/zarf-init-bigbang#93).

Closes #46.

## Background

Zarf v0.78.0 added a new alpine/socat-based in-cluster proxy sidecar to the upstream `zarf-registry` component. The `PROXY_IMAGE_*` template variables are required by the upstream init package starting in that release; without them, `zarf dev lint` and `zarf package create` will fail once #26 (the v0.59.0 → v0.78.0 Renovate bump) lands.

## Test plan

- [ ] After #26 lands and this branch is rebased on `main`, CI's `Test packaging` job (`build (full)`) goes green
- [ ] `make lint` succeeds locally without `package template variable "PROXY_IMAGE_*" was not set` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)