### PR TITLE
Drop obsolete INJECTOR_VERSION / INJECTOR_AMD64_SHASUM --set flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@ lint:
 	--set AGENT_IMAGE_DOMAIN="registry1.dso.mil/" \
 	--set AGENT_IMAGE="ironbank/opensource/defenseunicorns/zarf/zarf-agent" \
 	--set AGENT_IMAGE_TAG=v$(ZARF_VERSION) \
-	--set INJECTOR_VERSION="2025-03-24" \
-	--set INJECTOR_AMD64_SHASUM="a78d66b9e2b00a22edd9b4e6432a4d934621e3757f09493b12f688c7c9baca93" \
 	--set GITEA_IMAGE=registry1.dso.mil/ironbank/opensource/go-gitea/gitea:v$(GITEA_VERSION)
 
 .PHONY: build-full
@@ -34,8 +32,6 @@ build-full:
 	--set AGENT_IMAGE_DOMAIN="registry1.dso.mil/" \
 	--set AGENT_IMAGE="ironbank/opensource/defenseunicorns/zarf/zarf-agent" \
 	--set AGENT_IMAGE_TAG=v$(ZARF_VERSION) \
-	--set INJECTOR_VERSION="2025-03-24" \
-	--set INJECTOR_AMD64_SHASUM="a78d66b9e2b00a22edd9b4e6432a4d934621e3757f09493b12f688c7c9baca93" \
 	--set GITEA_IMAGE=registry1.dso.mil/ironbank/opensource/go-gitea/gitea:v$(GITEA_VERSION) && \
 	mv $(BUILD_DIR)/zarf-init-amd64-v$(ZARF_VERSION).tar.zst $(BUILD_DIR)/zarf-init-full-amd64-v$(ZARF_VERSION).tar.zst
 


### PR DESCRIPTION
## Summary

- Removes the `--set INJECTOR_VERSION=...` and `--set INJECTOR_AMD64_SHASUM=...` flags from both the `lint` and `build-full` Makefile targets.
- These template variables no longer exist in upstream `zarf-dev/zarf` starting with v0.78.0 — the injector binary was split into its own repo (`zarf-dev/zarf-injector`) and the upstream `packages/zarf-registry/zarf.yaml` now hardcodes the source URL, version, and shasum.
- The flags were silently ignored by current zarf (which only errors on *missing* template vars, not extra `--set` flags), so this is dead-code cleanup.

This is the k3s-ha equivalent of radiusmethod/zarf-init-bigbang#96 (which closed radiusmethod/zarf-init-bigbang#95).

Closes #47.

## ⚠️ Merge order

This PR is **blocked on #26 and #48 landing first**:
- #26 — `Update dependency zarf-dev/zarf to v0.78.0` (the upstream bump that obsoletes these flags)
- #48 — Wire `PROXY_IMAGE_*` template vars (required by v0.78.0's new socat sidecar)

Today's `zarf/full/zarf.yaml` still imports `init:v0.59.0`, where the injector templates *do* exist. Removing the `--set` flags before #26 lands will re-break `make lint`.

CI on this branch will fail until #26 + #48 are in `main` and this branch is rebased. **Do not merge this PR until both #26 and #48 are merged.**

## Test plan

- [ ] After #26 and #48 merge, rebase this branch on `main`
- [ ] Confirm CI (`Test packaging` → `build (full)`) goes green
- [ ] `make lint` and `make build-full` succeed locally without warnings about unknown `--set` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)